### PR TITLE
[ config ] Do not search any parent directories for git repo

### DIFF
--- a/apkg/config.py
+++ b/apkg/config.py
@@ -80,7 +80,7 @@ if not PACKAGE_SOURCES_PATH.exists():
   PACKAGE_SOURCES_PATH.mkdir()
 
 try:
-  REPO = git.Repo(INDEX_REPOSITORY_PATH, search_parent_directories=True)
+  REPO = git.Repo(INDEX_REPOSITORY_PATH, search_parent_directories=False)
 except:
   try:
     REPO = git.Repo.clone_from(INDEX_REPOSITORY_URL, INDEX_REPOSITORY_PATH)


### PR DESCRIPTION
The parent directory of `INDEX_REPOSITORY_PATH` is just user's home in this case, which can never be the git repo of package-index.

If there is a `.git/` under home (I personally keep track of dotfiles in `$HOME/.git`), setting `search_parent_directories` to `True` will confuse agda-pkg, which can lead to unexpected results (e.g., `apkg init` will not index any libraries at all).