### PR TITLE
Update nixos.py

### DIFF
--- a/apkg/commands/nixos.py
+++ b/apkg/commands/nixos.py
@@ -35,7 +35,7 @@ def nixos(): pass
              , is_flag=True
              , help='Yes for everything.')
 @clog.simple_verbosity_option(logger)
-def nixos():
+def nixos(yes):
   """Set up a NixOS environment for Agda"""
   MSG = "Agda-pkg will copy the following files to the current directory."
   click.echo(MSG)


### PR DESCRIPTION
Super quick fix; since the `nixos` function doesn't have a parameter for the `yes` click option, this command always blows up with `TypeError: nixos() got an unexpected keyword argument 'yes'`. This commit adds the missing parameter.